### PR TITLE
chore: milestone 2 polish — error feedback, component extraction, copy cleanup

### DIFF
--- a/app/(tabs)/(tend)/log/activity.tsx
+++ b/app/(tabs)/(tend)/log/activity.tsx
@@ -16,6 +16,7 @@ import { nowLocalIso } from '@/lib/utils/timestamp';
 import { colors, lineHeight, spacing, typeScale } from '@/constants/theme';
 import { colorForActivityLabel } from '@/constants/chipColors';
 import { logScreenStyles } from '@/constants/sharedStyles';
+import { messages } from '@/constants/messages';
 import type { Db } from '@/lib/db/queries';
 import type { Label } from '@/lib/db/query-types';
 
@@ -155,7 +156,7 @@ export default function LogActivityScreen() {
 
           {saveError && (
             <Text style={logScreenStyles.saveErrorText} testID="activity-save-error">
-              Something went wrong. Your entry was not saved.
+              {messages.saveError}
             </Text>
           )}
 

--- a/app/(tabs)/(tend)/log/activity.tsx
+++ b/app/(tabs)/(tend)/log/activity.tsx
@@ -28,6 +28,7 @@ export default function LogActivityScreen() {
   const [rawSuggestions, setRawSuggestions] = useState<Label[]>([]);
   const [chips, setChips] = useState<Label[]>([]);
   const [showConfirmation, setShowConfirmation] = useState(false);
+  const [saveError, setSaveError] = useState(false);
 
   const activityEntryType = entryTypes.find((t) => t.name === 'Activity');
 
@@ -82,6 +83,7 @@ export default function LogActivityScreen() {
       setShowConfirmation(true);
     } catch (err) {
       console.error('[LogActivityScreen] failed to save entry:', err);
+      setSaveError(true);
     }
   }
 
@@ -151,11 +153,17 @@ export default function LogActivityScreen() {
             </View>
           )}
 
+          {saveError && (
+            <Text style={logScreenStyles.saveErrorText} testID="activity-save-error">
+              Something went wrong. Your entry was not saved.
+            </Text>
+          )}
+
           {chips.length > 0 && (
             <View style={logScreenStyles.saveButton}>
               <Button
                 label="Save"
-                onPress={() => { void handleSave(); }}
+                onPress={() => { setSaveError(false); void handleSave(); }}
                 testID="activity-save-button"
               />
             </View>

--- a/app/(tabs)/(tend)/log/activity.tsx
+++ b/app/(tabs)/(tend)/log/activity.tsx
@@ -8,7 +8,7 @@ import {
   View,
 } from 'react-native';
 import { useRouter } from 'expo-router';
-import { Screen, SearchBar, Chip, Button, SaveConfirmation } from '@/components';
+import { Screen, SearchBar, Chip, Button, SaveConfirmation, SaveErrorMessage } from '@/components';
 import { useEntryTypes } from '@/hooks';
 import { getLabels, saveEntry, createLabel } from '@/lib/db/queries';
 import { getDb } from '@/lib/db/database';
@@ -16,7 +16,6 @@ import { nowLocalIso } from '@/lib/utils/timestamp';
 import { colors, lineHeight, spacing, typeScale } from '@/constants/theme';
 import { colorForActivityLabel } from '@/constants/chipColors';
 import { logScreenStyles } from '@/constants/sharedStyles';
-import { messages } from '@/constants/messages';
 import type { Db } from '@/lib/db/queries';
 import type { Label } from '@/lib/db/query-types';
 
@@ -154,11 +153,7 @@ export default function LogActivityScreen() {
             </View>
           )}
 
-          {saveError && (
-            <Text style={logScreenStyles.saveErrorText} testID="activity-save-error">
-              {messages.saveError}
-            </Text>
-          )}
+          <SaveErrorMessage visible={saveError} testID="activity-save-error" />
 
           {chips.length > 0 && (
             <View style={logScreenStyles.saveButton}>

--- a/app/(tabs)/(tend)/log/emotion/tier2.tsx
+++ b/app/(tabs)/(tend)/log/emotion/tier2.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 import { useRouter, useLocalSearchParams } from 'expo-router';
-import { Screen, SplitPane, SplitPaneRow, Chip, Button, SaveConfirmation } from '@/components';
+import { Screen, SplitPane, SplitPaneRow, Chip, Button, SaveConfirmation, SaveErrorMessage } from '@/components';
 import { useEntryTypes } from '@/hooks';
 import { getTier1EmotionLabels, getLabelsByParent, saveEntry } from '@/lib/db/queries';
 import { getDb } from '@/lib/db/database';
@@ -9,7 +9,6 @@ import { nowLocalIso } from '@/lib/utils/timestamp';
 import { colorForEmotionLabel } from '@/constants/chipColors';
 import { spacing } from '@/constants/theme';
 import { logScreenStyles } from '@/constants/sharedStyles';
-import { messages } from '@/constants/messages';
 import type { Db } from '@/lib/db/queries';
 import type { Label } from '@/lib/db/query-types';
 
@@ -145,11 +144,7 @@ export default function LogEmotionScreen2() {
           </View>
         )}
 
-        {saveError && (
-          <Text style={logScreenStyles.saveErrorText} testID="emotion-save-error">
-            {messages.saveError}
-          </Text>
-        )}
+        <SaveErrorMessage visible={saveError} testID="emotion-save-error" />
 
         {chipLabel && (
           <View style={styles.saveButton}>

--- a/app/(tabs)/(tend)/log/emotion/tier2.tsx
+++ b/app/(tabs)/(tend)/log/emotion/tier2.tsx
@@ -9,6 +9,7 @@ import { nowLocalIso } from '@/lib/utils/timestamp';
 import { colorForEmotionLabel } from '@/constants/chipColors';
 import { spacing } from '@/constants/theme';
 import { logScreenStyles } from '@/constants/sharedStyles';
+import { messages } from '@/constants/messages';
 import type { Db } from '@/lib/db/queries';
 import type { Label } from '@/lib/db/query-types';
 
@@ -146,7 +147,7 @@ export default function LogEmotionScreen2() {
 
         {saveError && (
           <Text style={logScreenStyles.saveErrorText} testID="emotion-save-error">
-            Something went wrong. Your entry was not saved.
+            {messages.saveError}
           </Text>
         )}
 

--- a/app/(tabs)/(tend)/log/emotion/tier2.tsx
+++ b/app/(tabs)/(tend)/log/emotion/tier2.tsx
@@ -31,6 +31,7 @@ export default function LogEmotionScreen2() {
       : null
   );
   const [showConfirmation, setShowConfirmation] = useState(false);
+  const [saveError, setSaveError] = useState(false);
 
   const emotionEntryType = entryTypes.find((t) => t.name === 'Emotion');
 
@@ -89,6 +90,7 @@ export default function LogEmotionScreen2() {
       setShowConfirmation(true);
     } catch (err) {
       console.error('[LogEmotionScreen2] failed to save entry:', err);
+      setSaveError(true);
     }
   }
 
@@ -142,11 +144,17 @@ export default function LogEmotionScreen2() {
           </View>
         )}
 
+        {saveError && (
+          <Text style={logScreenStyles.saveErrorText} testID="emotion-save-error">
+            Something went wrong. Your entry was not saved.
+          </Text>
+        )}
+
         {chipLabel && (
           <View style={styles.saveButton}>
             <Button
               label="Save"
-              onPress={() => { void handleSave(); }}
+              onPress={() => { setSaveError(false); void handleSave(); }}
               testID="emotion-save-button"
             />
           </View>

--- a/app/(tabs)/(tend)/log/emotion/tier3.tsx
+++ b/app/(tabs)/(tend)/log/emotion/tier3.tsx
@@ -9,6 +9,7 @@ import { nowLocalIso } from '@/lib/utils/timestamp';
 import { colorForEmotionLabel } from '@/constants/chipColors';
 import { colors, lineHeight, spacing, typeScale } from '@/constants/theme';
 import { logScreenStyles } from '@/constants/sharedStyles';
+import { messages } from '@/constants/messages';
 import type { Db } from '@/lib/db/queries';
 import type { Label } from '@/lib/db/query-types';
 
@@ -144,7 +145,7 @@ export default function LogEmotionScreen3() {
 
         {saveError && (
           <Text style={logScreenStyles.saveErrorText} testID="emotion-save-error">
-            Something went wrong. Your entry was not saved.
+            {messages.saveError}
           </Text>
         )}
 

--- a/app/(tabs)/(tend)/log/emotion/tier3.tsx
+++ b/app/(tabs)/(tend)/log/emotion/tier3.tsx
@@ -32,6 +32,7 @@ export default function LogEmotionScreen3() {
       : null
   );
   const [showConfirmation, setShowConfirmation] = useState(false);
+  const [saveError, setSaveError] = useState(false);
 
   const emotionEntryType = entryTypes.find((t) => t.name === 'Emotion');
 
@@ -81,6 +82,7 @@ export default function LogEmotionScreen3() {
       setShowConfirmation(true);
     } catch (err) {
       console.error('[LogEmotionScreen3] failed to save entry:', err);
+      setSaveError(true);
     }
   }
 
@@ -140,11 +142,17 @@ export default function LogEmotionScreen3() {
           </View>
         )}
 
+        {saveError && (
+          <Text style={logScreenStyles.saveErrorText} testID="emotion-save-error">
+            Something went wrong. Your entry was not saved.
+          </Text>
+        )}
+
         {chipLabel && (
           <View style={styles.saveButton}>
             <Button
               label="Save"
-              onPress={() => { void handleSave(); }}
+              onPress={() => { setSaveError(false); void handleSave(); }}
               testID="emotion-save-button"
             />
           </View>

--- a/app/(tabs)/(tend)/log/emotion/tier3.tsx
+++ b/app/(tabs)/(tend)/log/emotion/tier3.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 import { useLocalSearchParams, useRouter } from 'expo-router';
-import { Screen, SplitPane, SplitPaneRow, Chip, Button, SaveConfirmation } from '@/components';
+import { Screen, SplitPane, SplitPaneRow, Chip, Button, SaveConfirmation, SaveErrorMessage } from '@/components';
 import { useEntryTypes } from '@/hooks';
 import { getLabelsByParent, saveEntry } from '@/lib/db/queries';
 import { getDb } from '@/lib/db/database';
@@ -9,7 +9,6 @@ import { nowLocalIso } from '@/lib/utils/timestamp';
 import { colorForEmotionLabel } from '@/constants/chipColors';
 import { colors, lineHeight, spacing, typeScale } from '@/constants/theme';
 import { logScreenStyles } from '@/constants/sharedStyles';
-import { messages } from '@/constants/messages';
 import type { Db } from '@/lib/db/queries';
 import type { Label } from '@/lib/db/query-types';
 
@@ -143,11 +142,7 @@ export default function LogEmotionScreen3() {
           </View>
         )}
 
-        {saveError && (
-          <Text style={logScreenStyles.saveErrorText} testID="emotion-save-error">
-            {messages.saveError}
-          </Text>
-        )}
+        <SaveErrorMessage visible={saveError} testID="emotion-save-error" />
 
         {chipLabel && (
           <View style={styles.saveButton}>

--- a/app/(tabs)/(tend)/log/food.tsx
+++ b/app/(tabs)/(tend)/log/food.tsx
@@ -8,7 +8,7 @@ import {
   View,
 } from 'react-native';
 import { useRouter } from 'expo-router';
-import { Screen, SearchBar, Chip, Button, SaveConfirmation } from '@/components';
+import { Screen, SearchBar, Chip, Button, SaveConfirmation, SaveErrorMessage } from '@/components';
 import { useEntryTypes } from '@/hooks';
 import { getLabels, saveEntry, createLabel } from '@/lib/db/queries';
 import { getDb } from '@/lib/db/database';
@@ -16,7 +16,6 @@ import { nowLocalIso, getMealContext } from '@/lib/utils/timestamp';
 import { colors, lineHeight, spacing, typeScale } from '@/constants/theme';
 import { colorForFoodLabel } from '@/constants/chipColors';
 import { logScreenStyles } from '@/constants/sharedStyles';
-import { messages } from '@/constants/messages';
 import type { Db } from '@/lib/db/queries';
 import type { Label } from '@/lib/db/query-types';
 
@@ -157,11 +156,7 @@ export default function LogFoodScreen() {
             </View>
           )}
 
-          {saveError && (
-            <Text style={logScreenStyles.saveErrorText} testID="food-save-error">
-              {messages.saveError}
-            </Text>
-          )}
+          <SaveErrorMessage visible={saveError} testID="food-save-error" />
 
           {chips.length > 0 && (
             <View style={logScreenStyles.saveButton}>

--- a/app/(tabs)/(tend)/log/food.tsx
+++ b/app/(tabs)/(tend)/log/food.tsx
@@ -16,6 +16,7 @@ import { nowLocalIso, getMealContext } from '@/lib/utils/timestamp';
 import { colors, lineHeight, spacing, typeScale } from '@/constants/theme';
 import { colorForFoodLabel } from '@/constants/chipColors';
 import { logScreenStyles } from '@/constants/sharedStyles';
+import { messages } from '@/constants/messages';
 import type { Db } from '@/lib/db/queries';
 import type { Label } from '@/lib/db/query-types';
 
@@ -158,7 +159,7 @@ export default function LogFoodScreen() {
 
           {saveError && (
             <Text style={logScreenStyles.saveErrorText} testID="food-save-error">
-              Something went wrong. Your entry was not saved.
+              {messages.saveError}
             </Text>
           )}
 

--- a/app/(tabs)/(tend)/log/food.tsx
+++ b/app/(tabs)/(tend)/log/food.tsx
@@ -28,6 +28,7 @@ export default function LogFoodScreen() {
   const [rawSuggestions, setRawSuggestions] = useState<Label[]>([]);
   const [chips, setChips] = useState<Label[]>([]);
   const [showConfirmation, setShowConfirmation] = useState(false);
+  const [saveError, setSaveError] = useState(false);
 
   const foodEntryType = entryTypes.find((t) => t.name === 'Food');
   const mealContext = useMemo(() => getMealContext(nowLocalIso()), []);
@@ -83,6 +84,7 @@ export default function LogFoodScreen() {
       setShowConfirmation(true);
     } catch (err) {
       console.error('[LogFoodScreen] failed to save entry:', err);
+      setSaveError(true);
     }
   }
 
@@ -154,11 +156,17 @@ export default function LogFoodScreen() {
             </View>
           )}
 
+          {saveError && (
+            <Text style={logScreenStyles.saveErrorText} testID="food-save-error">
+              Something went wrong. Your entry was not saved.
+            </Text>
+          )}
+
           {chips.length > 0 && (
             <View style={logScreenStyles.saveButton}>
               <Button
                 label="Save"
-                onPress={() => { void handleSave(); }}
+                onPress={() => { setSaveError(false); void handleSave(); }}
                 testID="food-save-button"
               />
             </View>

--- a/app/(tabs)/(tend)/log/hydration.tsx
+++ b/app/(tabs)/(tend)/log/hydration.tsx
@@ -1,14 +1,13 @@
 import React, { useState, useEffect } from 'react';
 import { StyleSheet, Text, TextInput, View } from 'react-native';
 import { useRouter } from 'expo-router';
-import { Screen, NumericInput, Button, SaveConfirmation } from '@/components';
+import { Screen, NumericInput, Button, SaveConfirmation, SaveErrorMessage } from '@/components';
 import { useEntryTypes } from '@/hooks';
 import { saveEntry, getDailyHydrationTotal } from '@/lib/db/queries';
 import { getDb } from '@/lib/db/database';
 import { nowLocalIso } from '@/lib/utils/timestamp';
 import { colors, lineHeight, spacing, typeScale } from '@/constants/theme';
 import { logScreenStyles } from '@/constants/sharedStyles';
-import { messages } from '@/constants/messages';
 import type { Db } from '@/lib/db/queries';
 
 export default function LogHydrationScreen() {
@@ -88,11 +87,7 @@ export default function LogHydrationScreen() {
           testID="hydration-notes-input"
         />
 
-        {saveError && (
-          <Text style={logScreenStyles.saveErrorText} testID="hydration-save-error">
-            {messages.saveError}
-          </Text>
-        )}
+        <SaveErrorMessage visible={saveError} testID="hydration-save-error" />
 
         {oz.trim() !== '' && (
           <View style={logScreenStyles.saveButton}>

--- a/app/(tabs)/(tend)/log/hydration.tsx
+++ b/app/(tabs)/(tend)/log/hydration.tsx
@@ -17,6 +17,7 @@ export default function LogHydrationScreen() {
   const [notes, setNotes] = useState('');
   const [dailyTotal, setDailyTotal] = useState<number>(0);
   const [showConfirmation, setShowConfirmation] = useState(false);
+  const [saveError, setSaveError] = useState(false);
 
   const hydrationEntryType = entryTypes.find((t) => t.name === 'Hydration');
 
@@ -51,6 +52,7 @@ export default function LogHydrationScreen() {
       setShowConfirmation(true);
     } catch (err) {
       console.error('[LogHydrationScreen] failed to save entry:', err);
+      setSaveError(true);
     }
   }
 
@@ -85,11 +87,17 @@ export default function LogHydrationScreen() {
           testID="hydration-notes-input"
         />
 
+        {saveError && (
+          <Text style={logScreenStyles.saveErrorText} testID="hydration-save-error">
+            Something went wrong. Your entry was not saved.
+          </Text>
+        )}
+
         {oz.trim() !== '' && (
           <View style={logScreenStyles.saveButton}>
             <Button
               label="Save"
-              onPress={handleSave}
+              onPress={() => { setSaveError(false); void handleSave(); }}
               testID="hydration-save-button"
             />
           </View>

--- a/app/(tabs)/(tend)/log/hydration.tsx
+++ b/app/(tabs)/(tend)/log/hydration.tsx
@@ -8,6 +8,7 @@ import { getDb } from '@/lib/db/database';
 import { nowLocalIso } from '@/lib/utils/timestamp';
 import { colors, lineHeight, spacing, typeScale } from '@/constants/theme';
 import { logScreenStyles } from '@/constants/sharedStyles';
+import { messages } from '@/constants/messages';
 import type { Db } from '@/lib/db/queries';
 
 export default function LogHydrationScreen() {
@@ -89,7 +90,7 @@ export default function LogHydrationScreen() {
 
         {saveError && (
           <Text style={logScreenStyles.saveErrorText} testID="hydration-save-error">
-            Something went wrong. Your entry was not saved.
+            {messages.saveError}
           </Text>
         )}
 

--- a/app/(tabs)/(tend)/log/physical.tsx
+++ b/app/(tabs)/(tend)/log/physical.tsx
@@ -29,6 +29,7 @@ import { nowLocalIso } from '@/lib/utils/timestamp';
 import { colors, lineHeight, spacing, typeScale } from '@/constants/theme';
 import { colorForPhysicalLabel } from '@/constants/chipColors';
 import { logScreenStyles } from '@/constants/sharedStyles';
+import { messages } from '@/constants/messages';
 import type { Db } from '@/lib/db/queries';
 import type { PhysicalStateLabel } from '@/lib/db/query-types';
 
@@ -350,8 +351,8 @@ export default function LogPhysicalScreen() {
           )}
 
           {saveError && (
-            <Text style={styles.saveErrorText} testID="physical-save-error">
-              Something went wrong. Your entry was not saved.
+            <Text style={logScreenStyles.saveErrorText} testID="physical-save-error">
+              {messages.saveError}
             </Text>
           )}
 
@@ -421,12 +422,5 @@ const styles = StyleSheet.create({
     flexWrap: 'wrap',
     gap: spacing.elementGap,
     marginTop: spacing.sectionGap,
-  },
-  saveErrorText: {
-    fontFamily: typeScale.bodyMedium.family,
-    fontSize: typeScale.bodyMedium.size,
-    lineHeight: lineHeight(typeScale.bodyMedium),
-    color: colors.chrome,
-    marginTop: spacing.elementGap,
   },
 });

--- a/app/(tabs)/(tend)/log/physical.tsx
+++ b/app/(tabs)/(tend)/log/physical.tsx
@@ -14,6 +14,7 @@ import {
   Chip,
   Button,
   SaveConfirmation,
+  SaveErrorMessage,
   EnergySlider,
   SeverityRow,
 } from '@/components';
@@ -29,7 +30,6 @@ import { nowLocalIso } from '@/lib/utils/timestamp';
 import { colors, lineHeight, spacing, typeScale } from '@/constants/theme';
 import { colorForPhysicalLabel } from '@/constants/chipColors';
 import { logScreenStyles } from '@/constants/sharedStyles';
-import { messages } from '@/constants/messages';
 import type { Db } from '@/lib/db/queries';
 import type { PhysicalStateLabel } from '@/lib/db/query-types';
 
@@ -350,11 +350,7 @@ export default function LogPhysicalScreen() {
             </View>
           )}
 
-          {saveError && (
-            <Text style={logScreenStyles.saveErrorText} testID="physical-save-error">
-              {messages.saveError}
-            </Text>
-          )}
+          <SaveErrorMessage visible={saveError} testID="physical-save-error" />
 
           {canSubmit && (
             <View style={logScreenStyles.saveButton}>

--- a/app/(tabs)/(tend)/log/sleep.tsx
+++ b/app/(tabs)/(tend)/log/sleep.tsx
@@ -1,14 +1,13 @@
 import React, { useState } from 'react';
 import { Text, TextInput, View } from 'react-native';
 import { useRouter } from 'expo-router';
-import { Screen, NumericInput, Button, SaveConfirmation } from '@/components';
+import { Screen, NumericInput, Button, SaveConfirmation, SaveErrorMessage } from '@/components';
 import { useEntryTypes } from '@/hooks';
 import { saveEntry } from '@/lib/db/queries';
 import { getDb } from '@/lib/db/database';
 import { nowLocalIso } from '@/lib/utils/timestamp';
 import { colors } from '@/constants/theme';
 import { logScreenStyles } from '@/constants/sharedStyles';
-import { messages } from '@/constants/messages';
 import type { Db } from '@/lib/db/queries';
 
 export default function LogSleepScreen() {
@@ -68,11 +67,7 @@ export default function LogSleepScreen() {
           testID="sleep-notes-input"
         />
 
-        {saveError && (
-          <Text style={logScreenStyles.saveErrorText} testID="sleep-save-error">
-            {messages.saveError}
-          </Text>
-        )}
+        <SaveErrorMessage visible={saveError} testID="sleep-save-error" />
 
         {hours.trim() !== '' && (
           <View style={logScreenStyles.saveButton}>

--- a/app/(tabs)/(tend)/log/sleep.tsx
+++ b/app/(tabs)/(tend)/log/sleep.tsx
@@ -8,6 +8,7 @@ import { getDb } from '@/lib/db/database';
 import { nowLocalIso } from '@/lib/utils/timestamp';
 import { colors } from '@/constants/theme';
 import { logScreenStyles } from '@/constants/sharedStyles';
+import { messages } from '@/constants/messages';
 import type { Db } from '@/lib/db/queries';
 
 export default function LogSleepScreen() {
@@ -69,7 +70,7 @@ export default function LogSleepScreen() {
 
         {saveError && (
           <Text style={logScreenStyles.saveErrorText} testID="sleep-save-error">
-            Something went wrong. Your entry was not saved.
+            {messages.saveError}
           </Text>
         )}
 

--- a/app/(tabs)/(tend)/log/sleep.tsx
+++ b/app/(tabs)/(tend)/log/sleep.tsx
@@ -16,6 +16,7 @@ export default function LogSleepScreen() {
   const [hours, setHours] = useState('');
   const [notes, setNotes] = useState('');
   const [showConfirmation, setShowConfirmation] = useState(false);
+  const [saveError, setSaveError] = useState(false);
 
   const sleepEntryType = entryTypes.find((t) => t.name === 'Sleep');
 
@@ -35,6 +36,7 @@ export default function LogSleepScreen() {
       setShowConfirmation(true);
     } catch (err) {
       console.error('[LogSleepScreen] failed to save entry:', err);
+      setSaveError(true);
     }
   }
 
@@ -65,11 +67,17 @@ export default function LogSleepScreen() {
           testID="sleep-notes-input"
         />
 
+        {saveError && (
+          <Text style={logScreenStyles.saveErrorText} testID="sleep-save-error">
+            Something went wrong. Your entry was not saved.
+          </Text>
+        )}
+
         {hours.trim() !== '' && (
           <View style={logScreenStyles.saveButton}>
             <Button
               label="Save"
-              onPress={handleSave}
+              onPress={() => { setSaveError(false); void handleSave(); }}
               testID="sleep-save-button"
             />
           </View>

--- a/app/(tabs)/trace.tsx
+++ b/app/(tabs)/trace.tsx
@@ -108,7 +108,7 @@ export default function TraceScreen() {
     return (
       <Screen>
         <View style={styles.emptyContainer}>
-          <Text style={styles.emptyText} testID="trace-load-error">
+          <Text style={styles.errorText} testID="trace-load-error">
             {messages.traceLoadError}
           </Text>
         </View>
@@ -216,5 +216,11 @@ const styles = StyleSheet.create({
     fontSize: typeScale.bodyMedium.size,
     lineHeight: lineHeight(typeScale.bodyMedium),
     color: colors.chrome,
+  },
+  errorText: {
+    fontFamily: typeScale.bodyMedium.family,
+    fontSize: typeScale.bodyMedium.size,
+    lineHeight: lineHeight(typeScale.bodyMedium),
+    color: colors.error,
   },
 });

--- a/app/(tabs)/trace.tsx
+++ b/app/(tabs)/trace.tsx
@@ -9,6 +9,7 @@ import { formatEntryTime } from '@/lib/utils/timestamp';
 import { colors, typeScale, lineHeight, spacing } from '@/constants/theme';
 import type { EntryWithLabels } from '@/lib/db/query-types';
 import type { TraceSection } from '@/lib/utils/traceUtils';
+import { messages } from '@/constants/messages';
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -108,7 +109,7 @@ export default function TraceScreen() {
       <Screen>
         <View style={styles.emptyContainer}>
           <Text style={styles.emptyText} testID="trace-load-error">
-            Could not load your entries.
+            {messages.traceLoadError}
           </Text>
         </View>
       </Screen>

--- a/app/(tabs)/trace.tsx
+++ b/app/(tabs)/trace.tsx
@@ -78,7 +78,7 @@ function EntryRow({ entry, expanded, onToggle }: EntryRowProps) {
 // ─── Screen ───────────────────────────────────────────────────────────────────
 
 export default function TraceScreen() {
-  const { sections, loading } = useTraceEntries();
+  const { sections, loading, error } = useTraceEntries();
   const [expandedIds, setExpandedIds] = useState<Set<number>>(new Set());
 
   useFocusEffect(
@@ -101,6 +101,18 @@ export default function TraceScreen() {
 
   if (loading) {
     return null;
+  }
+
+  if (error) {
+    return (
+      <Screen>
+        <View style={styles.emptyContainer}>
+          <Text style={styles.emptyText} testID="trace-load-error">
+            Could not load your entries.
+          </Text>
+        </View>
+      </Screen>
+    );
   }
 
   const isEmpty = sections.length === 0;

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,7 +4,7 @@ One row per PR. Most recent at the top.
 
 | PR | Description | Date |
 |----|-------------|------|
-| [#109](https://github.com/sfrankle/haven-app/pull/109) | Save error feedback on all log screens; TraceScreen shows error instead of blank on load failure | 2026-03-29 |
+| [#109](https://github.com/sfrankle/haven-app/pull/109) | Milestone 2 polish: error feedback on all log and trace screens, shared SaveErrorMessage component, copy aligned with voice guide | 2026-03-29 |
 | [#108](https://github.com/sfrankle/haven-app/pull/108) | 1 - Core Logging bug fixes. | 2026-03-27 |
 | [#106](https://github.com/sfrankle/haven-app/pull/106) | GitHub Actions workflow to build a sideloadable Android APK and attach it to a GitHub Release on `v*` tag push | 2026-03-27 |
 | [#104](https://github.com/sfrankle/haven-app/pull/104) | Unit tests for `colorForActivityLabel` — covers category color and fallback paths | 2026-03-26 |

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,7 @@ One row per PR. Most recent at the top.
 
 | PR | Description | Date |
 |----|-------------|------|
+| [#109](https://github.com/sfrankle/haven-app/pull/109) | Save error feedback on all log screens; TraceScreen shows error instead of blank on load failure | 2026-03-29 |
 | [#108](https://github.com/sfrankle/haven-app/pull/108) | 1 - Core Logging bug fixes. | 2026-03-27 |
 | [#106](https://github.com/sfrankle/haven-app/pull/106) | GitHub Actions workflow to build a sideloadable Android APK and attach it to a GitHub Release on `v*` tag push | 2026-03-27 |
 | [#104](https://github.com/sfrankle/haven-app/pull/104) | Unit tests for `colorForActivityLabel` — covers category color and fallback paths | 2026-03-26 |

--- a/src/__tests__/components/SaveErrorMessage.test.tsx
+++ b/src/__tests__/components/SaveErrorMessage.test.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { SaveErrorMessage } from '@/components/SaveErrorMessage';
+
+describe('SaveErrorMessage', () => {
+  it('renders error text when visible', () => {
+    const { getByTestId } = render(
+      <SaveErrorMessage visible testID="test-save-error" />
+    );
+    expect(getByTestId('test-save-error')).toBeTruthy();
+  });
+
+  it('renders nothing when not visible', () => {
+    const { queryByTestId } = render(
+      <SaveErrorMessage visible={false} testID="test-save-error" />
+    );
+    expect(queryByTestId('test-save-error')).toBeNull();
+  });
+
+  it('displays the standard save error message', () => {
+    const { getByTestId } = render(
+      <SaveErrorMessage visible testID="test-save-error" />
+    );
+    expect(getByTestId('test-save-error').props.children).toBe("Couldn't save. Try again.");
+  });
+});

--- a/src/__tests__/screens/LogActivityScreen.test.tsx
+++ b/src/__tests__/screens/LogActivityScreen.test.tsx
@@ -260,6 +260,18 @@ describe('LogActivityScreen', () => {
     expect(mockBack).toHaveBeenCalledTimes(1);
   });
 
+  it('shows an error message when saveEntry throws', async () => {
+    mockSaveEntry.mockRejectedValue(new Error('db error'));
+    const { getByTestId, queryByTestId } = render(<LogActivityScreen />);
+    act(() => { jest.advanceTimersByTime(200); });
+    await waitFor(() => getByTestId('activity-suggestion-1'));
+    fireEvent.press(getByTestId('activity-suggestion-1'));
+    await act(async () => {
+      fireEvent.press(getByTestId('activity-save-button'));
+    });
+    expect(queryByTestId('activity-save-error')).toBeTruthy();
+  });
+
   it('applies category colour to chip based on label categoryName', async () => {
     const { getByTestId } = render(<LogActivityScreen />);
     act(() => { jest.advanceTimersByTime(200); });

--- a/src/__tests__/screens/LogEmotionScreen2.test.tsx
+++ b/src/__tests__/screens/LogEmotionScreen2.test.tsx
@@ -203,4 +203,15 @@ describe('LogEmotionScreen2', () => {
       expect.objectContaining({ entryTypeId: 3, labelIds: [20] })
     );
   });
+
+  it('shows an error message when saveEntry throws', async () => {
+    mockSaveEntry.mockRejectedValue(new Error('db error'));
+    mockParams = { tier1Id: '11', chipLabelId: '20', chipLabelName: 'Connected' };
+    const { getByTestId, queryByTestId } = render(<LogEmotionScreen2 />);
+    await waitFor(() => getByTestId('emotion-save-button'));
+    await act(async () => {
+      fireEvent.press(getByTestId('emotion-save-button'));
+    });
+    expect(queryByTestId('emotion-save-error')).toBeTruthy();
+  });
 });

--- a/src/__tests__/screens/LogEmotionScreen3.test.tsx
+++ b/src/__tests__/screens/LogEmotionScreen3.test.tsx
@@ -165,4 +165,14 @@ describe('LogEmotionScreen3', () => {
       expect.objectContaining({ entryTypeId: 3, labelIds: [20] })
     );
   });
+
+  it('shows an error message when saveEntry throws', async () => {
+    mockSaveEntry.mockRejectedValue(new Error('db error'));
+    const { getByTestId, queryByTestId } = render(<LogEmotionScreen3 />);
+    await waitFor(() => getByTestId('emotion-save-button'));
+    await act(async () => {
+      fireEvent.press(getByTestId('emotion-save-button'));
+    });
+    expect(queryByTestId('emotion-save-error')).toBeTruthy();
+  });
 });

--- a/src/__tests__/screens/LogFoodScreen.test.tsx
+++ b/src/__tests__/screens/LogFoodScreen.test.tsx
@@ -266,6 +266,18 @@ describe('LogFoodScreen', () => {
     expect(mockBack).toHaveBeenCalledTimes(1);
   });
 
+  it('shows an error message when saveEntry throws', async () => {
+    mockSaveEntry.mockRejectedValue(new Error('db error'));
+    const { getByTestId, queryByTestId } = render(<LogFoodScreen />);
+    act(() => { jest.advanceTimersByTime(200); });
+    await waitFor(() => getByTestId('food-suggestion-1'));
+    fireEvent.press(getByTestId('food-suggestion-1'));
+    await act(async () => {
+      fireEvent.press(getByTestId('food-save-button'));
+    });
+    expect(queryByTestId('food-save-error')).toBeTruthy();
+  });
+
   it('applies food category colour to chip based on label categoryName', async () => {
     const { getByTestId } = render(<LogFoodScreen />);
     act(() => { jest.advanceTimersByTime(200); });

--- a/src/__tests__/screens/LogHydrationScreen.test.tsx
+++ b/src/__tests__/screens/LogHydrationScreen.test.tsx
@@ -5,7 +5,8 @@ import { useEntryTypes } from '@/hooks';
 import * as queries from '@/lib/db/queries';
 import * as timestamp from '@/lib/utils/timestamp';
 
-// Must be hoisted before module evaluation.
+const mockBack = jest.fn();
+
 jest.mock('expo-router', () => ({
   useRouter: () => ({ back: jest.fn(), replace: mockBack, push: jest.fn() }),
 }));
@@ -26,9 +27,6 @@ jest.mock('@/lib/utils/timestamp', () => ({
 jest.mock('@/lib/db/database', () => ({
   getDb: jest.fn().mockResolvedValue({}),
 }));
-
-// Declared after jest.mock; hoisting keeps mocks available at module level.
-const mockBack = jest.fn();
 
 const HYDRATION_ENTRY_TYPE: EntryType = {
   id: 4,

--- a/src/__tests__/screens/LogHydrationScreen.test.tsx
+++ b/src/__tests__/screens/LogHydrationScreen.test.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { render, fireEvent, act } from '@testing-library/react-native';
+import type { EntryType } from '@/lib/db/query-types';
+import { useEntryTypes } from '@/hooks';
+import * as queries from '@/lib/db/queries';
+import * as timestamp from '@/lib/utils/timestamp';
+
+// Must be hoisted before module evaluation.
+jest.mock('expo-router', () => ({
+  useRouter: () => ({ back: jest.fn(), replace: mockBack, push: jest.fn() }),
+}));
+
+jest.mock('@/hooks', () => ({
+  useEntryTypes: jest.fn(),
+}));
+
+jest.mock('@/lib/db/queries', () => ({
+  saveEntry: jest.fn(),
+  getDailyHydrationTotal: jest.fn(),
+}));
+
+jest.mock('@/lib/utils/timestamp', () => ({
+  nowLocalIso: jest.fn(),
+}));
+
+jest.mock('@/lib/db/database', () => ({
+  getDb: jest.fn().mockResolvedValue({}),
+}));
+
+// Declared after jest.mock; hoisting keeps mocks available at module level.
+const mockBack = jest.fn();
+
+const HYDRATION_ENTRY_TYPE: EntryType = {
+  id: 4,
+  name: 'Hydration',
+  title: 'Hydrate',
+  icon: 'water',
+  prompt: 'How much did you drink?',
+  measurementType: 'numeric',
+};
+
+const FIXED_ISO = '2026-03-12T09:00:00-08:00';
+
+// Import screen after mocks are set up.
+// eslint-disable-next-line import/first
+import LogHydrationScreen from '../../../app/(tabs)/(tend)/log/hydration';
+
+describe('LogHydrationScreen', () => {
+  const mockUseEntryTypes = jest.mocked(useEntryTypes);
+  const mockSaveEntry = jest.mocked(queries.saveEntry);
+  const mockGetDailyHydrationTotal = jest.mocked(queries.getDailyHydrationTotal);
+  const mockNowLocalIso = jest.mocked(timestamp.nowLocalIso);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    mockUseEntryTypes.mockReturnValue({
+      entryTypes: [HYDRATION_ENTRY_TYPE],
+      loading: false,
+      error: null,
+    });
+    mockSaveEntry.mockResolvedValue(1);
+    mockGetDailyHydrationTotal.mockResolvedValue(0);
+    mockNowLocalIso.mockReturnValue(FIXED_ISO);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('shows an error message when saveEntry throws', async () => {
+    mockSaveEntry.mockRejectedValue(new Error('db error'));
+    const { getByTestId, queryByTestId } = render(<LogHydrationScreen />);
+    await act(async () => {
+      fireEvent.press(getByTestId('hydration-save-button'));
+    });
+    expect(queryByTestId('hydration-save-error')).toBeTruthy();
+  });
+});

--- a/src/__tests__/screens/LogHydrationScreen.test.tsx
+++ b/src/__tests__/screens/LogHydrationScreen.test.tsx
@@ -71,6 +71,7 @@ describe('LogHydrationScreen', () => {
   it('shows an error message when saveEntry throws', async () => {
     mockSaveEntry.mockRejectedValue(new Error('db error'));
     const { getByTestId, queryByTestId } = render(<LogHydrationScreen />);
+    fireEvent.changeText(getByTestId('hydration-oz-input'), '16');
     await act(async () => {
       fireEvent.press(getByTestId('hydration-save-button'));
     });

--- a/src/__tests__/screens/LogSleepScreen.test.tsx
+++ b/src/__tests__/screens/LogSleepScreen.test.tsx
@@ -139,6 +139,16 @@ describe('LogSleepScreen', () => {
     expect(mockBack).toHaveBeenCalledTimes(1);
   });
 
+  it('shows an error message when saveEntry throws', async () => {
+    mockSaveEntry.mockRejectedValue(new Error('db error'));
+    const { getByTestId, queryByTestId } = render(<LogSleepScreen />);
+    fireEvent.changeText(getByTestId('sleep-hours-input'), '7');
+    await act(async () => {
+      fireEvent.press(getByTestId('sleep-save-button'));
+    });
+    expect(queryByTestId('sleep-save-error')).toBeTruthy();
+  });
+
   it('does not call saveEntry when navigating back without saving', () => {
     render(<LogSleepScreen />);
     // No interaction — saveEntry must not be called without an explicit submit.

--- a/src/__tests__/screens/TraceScreen.test.tsx
+++ b/src/__tests__/screens/TraceScreen.test.tsx
@@ -45,6 +45,12 @@ describe('TraceScreen', () => {
     jest.clearAllMocks();
   });
 
+  it('shows an error message when useTraceEntries returns an error', () => {
+    mockUseTraceEntries.mockReturnValue({ sections: [], loading: false, error: new Error('db error') });
+    const { getByTestId } = render(<TraceScreen />);
+    expect(getByTestId('trace-load-error')).toBeTruthy();
+  });
+
   it('renders nothing while loading', () => {
     mockUseTraceEntries.mockReturnValue({ sections: [], loading: true, error: null });
     const { queryByText } = render(<TraceScreen />);

--- a/src/components/SaveErrorMessage.tsx
+++ b/src/components/SaveErrorMessage.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { Text } from 'react-native';
+import { logScreenStyles } from '@/constants/sharedStyles';
+import { messages } from '@/constants/messages';
+
+interface SaveErrorMessageProps {
+  visible: boolean;
+  testID?: string;
+}
+
+export function SaveErrorMessage({ visible, testID }: SaveErrorMessageProps) {
+  if (!visible) return null;
+  return (
+    <Text style={logScreenStyles.saveErrorText} testID={testID}>
+      {messages.saveError}
+    </Text>
+  );
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -3,6 +3,7 @@ export { EntryTypeTile } from './EntryTypeTile';
 export { Chip } from './Chip';
 export { NumericInput } from './NumericInput';
 export { SaveConfirmation } from './SaveConfirmation';
+export { SaveErrorMessage } from './SaveErrorMessage';
 export { Screen } from './Screen';
 export { SearchBar } from './SearchBar';
 export { Surface } from './Surface';

--- a/src/constants/messages.ts
+++ b/src/constants/messages.ts
@@ -1,4 +1,4 @@
 export const messages = {
-  saveError: 'Something went wrong. Your entry was not saved.',
-  traceLoadError: 'Could not load your entries.',
+  saveError: "Couldn't save. Try again.",
+  traceLoadError: "Couldn't load your entries.",
 };

--- a/src/constants/messages.ts
+++ b/src/constants/messages.ts
@@ -1,0 +1,4 @@
+export const messages = {
+  saveError: 'Something went wrong. Your entry was not saved.',
+  traceLoadError: 'Could not load your entries.',
+};

--- a/src/constants/sharedStyles.ts
+++ b/src/constants/sharedStyles.ts
@@ -38,7 +38,7 @@ export const logScreenStyles = StyleSheet.create({
     fontFamily: typeScale.bodyMedium.family,
     fontSize: typeScale.bodyMedium.size,
     lineHeight: lineHeight(typeScale.bodyMedium),
-    color: colors.chrome,
+    color: colors.error,
     marginTop: spacing.elementGap,
   },
   promptPadded: {

--- a/src/constants/sharedStyles.ts
+++ b/src/constants/sharedStyles.ts
@@ -34,6 +34,13 @@ export const logScreenStyles = StyleSheet.create({
   saveButton: {
     marginTop: spacing.elementGap,
   },
+  saveErrorText: {
+    fontFamily: typeScale.bodyMedium.family,
+    fontSize: typeScale.bodyMedium.size,
+    lineHeight: lineHeight(typeScale.bodyMedium),
+    color: colors.chrome,
+    marginTop: spacing.elementGap,
+  },
   promptPadded: {
     paddingHorizontal: spacing.pagePadding,
   },


### PR DESCRIPTION
## Summary

Milestone 2 (Core Logging) wrap-up pass — polish and edge-case coverage before close:

- All log screens (food, activity, sleep, hydration, emotion tiers 2 & 3) now surface a visible error message when `saveEntry` throws, instead of silently dropping the failure
- TraceScreen renders an error message instead of hanging blank when `useTraceEntries` returns an error
- Extracted shared `SaveErrorMessage` component — removes duplicated error JSX from all log screens
- Error message strings consolidated into `constants/messages.ts`
- Error copy aligned with voice guide; trace error distinguished from empty state
- `saveErrorText` style added to `sharedStyles.ts` (single definition, shared across screens)

## Test plan
- [ ] New failing tests added first (RED), then implementation (GREEN) — TDD followed throughout
- [ ] All tests in affected files pass
- [ ] TypeScript clean (`npx tsc --noEmit`)
- [x] CI passing

## Closes
Contributes to Milestone 2 — 1: Core Logging

🤖 Generated with [Claude Code](https://claude.com/claude-code)