### PR TITLE
Physical: log severity 0 — symptom absent today

### DIFF
--- a/app/(tabs)/(tend)/log/physical.tsx
+++ b/app/(tabs)/(tend)/log/physical.tsx
@@ -24,48 +24,15 @@ import {
 } from '@/lib/db/queries';
 import { getDb } from '@/lib/db/database';
 import { nowLocalIso } from '@/lib/utils/timestamp';
+import { formatChipLabel } from '@/lib/utils/physicalChipLabel';
+import type { EnergyChip, StateChip, PhysicalChip } from '@/lib/utils/physicalChipLabel';
 import { colors, lineHeight, spacing, typeScale } from '@/constants/theme';
 import { colorForPhysicalLabel } from '@/constants/chipColors';
 import { logScreenStyles } from '@/constants/sharedStyles';
 import type { Db } from '@/lib/db/queries';
 import type { PhysicalStateLabel } from '@/lib/db/query-types';
 
-// ─── Types ─────────────────────────────────────────────────────────────────
-
-type EnergyChip = {
-  kind: 'energy';
-  id: 'energy';
-  value: number; // 1-5
-};
-
-type StateChip = {
-  kind: 'state';
-  id: number; // labelId
-  labelName: string;
-  parentName: string | null;
-  severity: number | null; // 1-5 or null
-};
-
-type PhysicalChip = EnergyChip | StateChip;
-
 // ─── Helpers ───────────────────────────────────────────────────────────────
-
-const WHOLE_BODY_NAMES = ['whole body', 'body'];
-
-function formatChipLabel(chip: PhysicalChip): string {
-  if (chip.kind === 'energy') {
-    return `Energy: ${chip.value}/5`;
-  }
-  const parentName = chip.parentName;
-  const showPrefix =
-    parentName !== null &&
-    !WHOLE_BODY_NAMES.includes(parentName.toLowerCase());
-  const base = showPrefix ? `${parentName}: ${chip.labelName}` : chip.labelName;
-  if (chip.severity !== null) {
-    return `${base} (${chip.severity}/5)`;
-  }
-  return base;
-}
 
 const SUGGESTION_LIMIT = 5;
 const SEVERITY_AUTO_DISMISS_MS = 2000;

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,7 @@ One row per PR. Most recent at the top.
 
 | PR | Description | Date |
 |----|-------------|------|
+| [#155](https://github.com/sfrankle/haven-app/pull/155) | Physical severity scale extended to include 0 ("absent"), so users can log zero-symptom check-ins and Trace displays "(absent)" for those chips | 2026-04-17 |
 | [#153](https://github.com/sfrankle/haven-app/pull/153) | Focus quick-log screen: tap a Focus pill on Tend to log all tracked items in one submission | 2026-04-16 |
 | [#151](https://github.com/sfrankle/haven-app/pull/151) | Edit and archive Focus: rename, add/remove pinned labels, archive from Tend or Settings; archived Focuses can be unarchived from Settings | 2026-04-15 |
 | [#150](https://github.com/sfrankle/haven-app/pull/150) | `FocusDropdown` now shows an inline error when focus creation fails (e.g. duplicate name) instead of silently leaving the modal open | 2026-04-15 |

--- a/maestro/flows/tend/log-physical-severity-zero.yaml
+++ b/maestro/flows/tend/log-physical-severity-zero.yaml
@@ -1,0 +1,31 @@
+appId: com.haven.app
+---
+- launchApp
+- assertVisible: "Attune"
+- tapOn: "Attune"
+- assertVisible:
+    id: "energy-slider"
+- assertVisible:
+    id: "physical-search"
+# Search for and select a sensation
+- tapOn:
+    id: "physical-search"
+- inputText: "Cramp"
+- assertVisible:
+    id: "physical-suggestion-*"
+- tapOn:
+    id: "physical-suggestion-*"
+# SeverityRow should appear after selecting a chip
+- assertVisible:
+    id: "physical-severity-row"
+# Tap severity 0 (absent)
+- tapOn:
+    text: "0"
+    id: "physical-severity-row"
+# Chip label should show "(absent)"
+- assertVisible:
+    text: ".*absent.*"
+# Save
+- tapOn:
+    id: "physical-save-button"
+- assertVisible: "Entry saved."

--- a/src/__tests__/physical-chip-label.test.ts
+++ b/src/__tests__/physical-chip-label.test.ts
@@ -1,0 +1,49 @@
+import { formatChipLabel } from '@/lib/utils/physicalChipLabel';
+
+describe('formatChipLabel', () => {
+  it('energy chip returns "Energy: N/5"', () => {
+    expect(formatChipLabel({ kind: 'energy', id: 'energy', value: 3 })).toBe('Energy: 3/5');
+  });
+
+  it('state chip with no severity returns label name only', () => {
+    expect(
+      formatChipLabel({ kind: 'state', id: 1, labelName: 'Fatigue', parentName: null, severity: null })
+    ).toBe('Fatigue');
+  });
+
+  it('state chip with severity 1 returns "(1/5)" suffix', () => {
+    expect(
+      formatChipLabel({ kind: 'state', id: 1, labelName: 'Fatigue', parentName: null, severity: 1 })
+    ).toBe('Fatigue (1/5)');
+  });
+
+  it('state chip with severity 5 returns "(5/5)" suffix', () => {
+    expect(
+      formatChipLabel({ kind: 'state', id: 1, labelName: 'Fatigue', parentName: null, severity: 5 })
+    ).toBe('Fatigue (5/5)');
+  });
+
+  it('state chip with severity 0 returns "(absent)" suffix', () => {
+    expect(
+      formatChipLabel({ kind: 'state', id: 1, labelName: 'Fatigue', parentName: null, severity: 0 })
+    ).toBe('Fatigue (absent)');
+  });
+
+  it('state chip with parent area prefix when parent is not whole-body', () => {
+    expect(
+      formatChipLabel({ kind: 'state', id: 1, labelName: 'Cramps', parentName: 'Gut', severity: null })
+    ).toBe('Gut: Cramps');
+  });
+
+  it('state chip with parent "body" skips prefix', () => {
+    expect(
+      formatChipLabel({ kind: 'state', id: 1, labelName: 'Fatigue', parentName: 'body', severity: null })
+    ).toBe('Fatigue');
+  });
+
+  it('state chip with severity 0 and area prefix shows "(absent)"', () => {
+    expect(
+      formatChipLabel({ kind: 'state', id: 1, labelName: 'Cramps', parentName: 'Gut', severity: 0 })
+    ).toBe('Gut: Cramps (absent)');
+  });
+});

--- a/src/components/SeverityRow.tsx
+++ b/src/components/SeverityRow.tsx
@@ -9,35 +9,45 @@ interface SeverityRowProps {
   testID?: string;
 }
 
-const SEVERITY_VALUES = [1, 2, 3, 4, 5] as const;
+const SEVERITY_VALUES = [0, 1, 2, 3, 4, 5] as const;
 
 export function SeverityRow({ value, onChange, onDismiss, testID }: SeverityRowProps) {
   return (
     <View style={styles.container} testID={testID}>
       <Text style={styles.label}>Severity</Text>
       <View style={styles.buttons}>
-        {SEVERITY_VALUES.map((sev) => (
-          <Pressable
-            key={sev}
-            style={[styles.button, value === sev && styles.buttonSelected]}
-            onPress={() => {
-              onChange(sev);
-              onDismiss();
-            }}
-            accessibilityRole="button"
-            accessibilityLabel={`Severity ${sev} of 5`}
-            accessibilityState={{ selected: value === sev }}
-          >
-            <Text
+        {SEVERITY_VALUES.map((sev) => {
+          const isZero = sev === 0;
+          const isSelected = value === sev;
+          return (
+            <Pressable
+              key={sev}
               style={[
-                styles.buttonText,
-                value === sev && styles.buttonTextSelected,
+                styles.button,
+                isZero && !isSelected && styles.buttonZero,
+                isSelected && styles.buttonSelected,
               ]}
+              onPress={() => {
+                onChange(sev);
+                onDismiss();
+              }}
+              accessibilityRole="button"
+              accessibilityLabel={
+                isZero ? 'Severity 0 — symptom absent' : `Severity ${sev} of 5`
+              }
+              accessibilityState={{ selected: isSelected }}
             >
-              {sev}
-            </Text>
-          </Pressable>
-        ))}
+              <Text
+                style={[
+                  styles.buttonText,
+                  isSelected && styles.buttonTextSelected,
+                ]}
+              >
+                {sev}
+              </Text>
+            </Pressable>
+          );
+        })}
       </View>
     </View>
   );
@@ -67,6 +77,11 @@ const styles = StyleSheet.create({
     backgroundColor: colors.surfaceVariant,
     alignItems: 'center',
     justifyContent: 'center',
+  },
+  buttonZero: {
+    backgroundColor: colors.surface,
+    borderWidth: 1,
+    borderColor: colors.chrome,
   },
   buttonSelected: {
     backgroundColor: colors.interactive,

--- a/src/components/__tests__/SeverityRow.test.tsx
+++ b/src/components/__tests__/SeverityRow.test.tsx
@@ -3,20 +3,46 @@ import { render, fireEvent } from '@testing-library/react-native';
 import { SeverityRow } from '../SeverityRow';
 
 describe('SeverityRow', () => {
-  it('renders 5 buttons for values 1-5', () => {
+  it('renders 6 buttons for values 0-5', () => {
     const { getAllByRole } = render(
       <SeverityRow value={null} onChange={jest.fn()} onDismiss={jest.fn()} />
     );
-    expect(getAllByRole('button').length).toBe(5);
+    expect(getAllByRole('button').length).toBe(6);
   });
 
-  it('displays labels 1 through 5', () => {
+  it('displays labels 0 through 5', () => {
     const { getByText } = render(
       <SeverityRow value={null} onChange={jest.fn()} onDismiss={jest.fn()} />
     );
-    for (let i = 1; i <= 5; i++) {
+    for (let i = 0; i <= 5; i++) {
       expect(getByText(String(i))).toBeTruthy();
     }
+  });
+
+  it('button "0" has accessibility label "Severity 0 — symptom absent"', () => {
+    const { getByLabelText } = render(
+      <SeverityRow value={null} onChange={jest.fn()} onDismiss={jest.fn()} />
+    );
+    expect(getByLabelText('Severity 0 — symptom absent')).toBeTruthy();
+  });
+
+  it('tapping "0" calls onChange(0) and onDismiss', () => {
+    const onChange = jest.fn();
+    const onDismiss = jest.fn();
+    const { getByText } = render(
+      <SeverityRow value={null} onChange={onChange} onDismiss={onDismiss} />
+    );
+    fireEvent.press(getByText('0'));
+    expect(onChange).toHaveBeenCalledWith(0);
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('value={0} marks button 0 as selected', () => {
+    const { getByLabelText } = render(
+      <SeverityRow value={0} onChange={jest.fn()} onDismiss={jest.fn()} />
+    );
+    const btn = getByLabelText('Severity 0 — symptom absent');
+    expect(btn.props.accessibilityState?.selected).toBe(true);
   });
 
   it('tapping a button calls onChange with that value', () => {
@@ -49,12 +75,12 @@ describe('SeverityRow', () => {
     expect(getByTestId('severity-row')).toBeTruthy();
   });
 
-  it('selected value button has accessible state selected', () => {
+  it('selected value button (non-zero) has accessible state selected', () => {
     const { getAllByRole } = render(
       <SeverityRow value={3} onChange={jest.fn()} onDismiss={jest.fn()} />
     );
     const buttons = getAllByRole('button');
-    // Button at index 2 is value 3
-    expect(buttons[2].props.accessibilityState?.selected).toBe(true);
+    // Button at index 3 is value 3 (0-indexed: 0,1,2,3,...)
+    expect(buttons[3].props.accessibilityState?.selected).toBe(true);
   });
 });

--- a/src/lib/utils/physicalChipLabel.ts
+++ b/src/lib/utils/physicalChipLabel.ts
@@ -1,4 +1,4 @@
-// ─── Types ──────────────────────────────────────────────────────────────────
+import { shouldShowAreaPrefix } from '@/lib/utils/traceUtils';
 
 export type EnergyChip = {
   kind: 'energy';
@@ -16,29 +16,14 @@ export type StateChip = {
 
 export type PhysicalChip = EnergyChip | StateChip;
 
-// ─── Constants ───────────────────────────────────────────────────────────────
-
-const WHOLE_BODY_NAMES = ['whole body', 'body'];
-
-// ─── Helper ──────────────────────────────────────────────────────────────────
-
-/**
- * Returns a formatted display label for a physical chip.
- *
- * - Energy chip: "Energy: N/5"
- * - State chip with no severity: label name (with optional area prefix)
- * - State chip with severity 1-5: "name (N/5)"
- * - State chip with severity 0: "name (absent)" — confirmed symptom-absent today
- */
+// severity 0 means "symptom absent today" — rendered as "(absent)" not "(0/5)"
 export function formatChipLabel(chip: PhysicalChip): string {
   if (chip.kind === 'energy') {
     return `Energy: ${chip.value}/5`;
   }
-  const parentName = chip.parentName;
-  const showPrefix =
-    parentName !== null &&
-    !WHOLE_BODY_NAMES.includes(parentName.toLowerCase());
-  const base = showPrefix ? `${parentName}: ${chip.labelName}` : chip.labelName;
+  const base = shouldShowAreaPrefix(chip.parentName)
+    ? `${chip.parentName}: ${chip.labelName}`
+    : chip.labelName;
   if (chip.severity === 0) {
     return `${base} (absent)`;
   }

--- a/src/lib/utils/physicalChipLabel.ts
+++ b/src/lib/utils/physicalChipLabel.ts
@@ -1,0 +1,49 @@
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+export type EnergyChip = {
+  kind: 'energy';
+  id: 'energy';
+  value: number;
+};
+
+export type StateChip = {
+  kind: 'state';
+  id: number;
+  labelName: string;
+  parentName: string | null;
+  severity: number | null;
+};
+
+export type PhysicalChip = EnergyChip | StateChip;
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+const WHOLE_BODY_NAMES = ['whole body', 'body'];
+
+// ─── Helper ──────────────────────────────────────────────────────────────────
+
+/**
+ * Returns a formatted display label for a physical chip.
+ *
+ * - Energy chip: "Energy: N/5"
+ * - State chip with no severity: label name (with optional area prefix)
+ * - State chip with severity 1-5: "name (N/5)"
+ * - State chip with severity 0: "name (absent)" — confirmed symptom-absent today
+ */
+export function formatChipLabel(chip: PhysicalChip): string {
+  if (chip.kind === 'energy') {
+    return `Energy: ${chip.value}/5`;
+  }
+  const parentName = chip.parentName;
+  const showPrefix =
+    parentName !== null &&
+    !WHOLE_BODY_NAMES.includes(parentName.toLowerCase());
+  const base = showPrefix ? `${parentName}: ${chip.labelName}` : chip.labelName;
+  if (chip.severity === 0) {
+    return `${base} (absent)`;
+  }
+  if (chip.severity !== null) {
+    return `${base} (${chip.severity}/5)`;
+  }
+  return base;
+}

--- a/src/lib/utils/traceUtils.ts
+++ b/src/lib/utils/traceUtils.ts
@@ -63,7 +63,9 @@ export function summariseEntry(entry: EntryWithLabels): string {
       const parentName = label.parentName;
       const stateName = shouldShowAreaPrefix(parentName) ? `${parentName}: ${label.name}` : label.name;
       if (numericValue === 0) return `Felt ${stateName} (absent)`;
-      return numericValue != null ? `Felt ${stateName} (${numericValue}/5)` : `Felt ${stateName}`;
+      return numericValue !== null && numericValue !== 0
+        ? `Felt ${stateName} (${numericValue}/5)`
+        : `Felt ${stateName}`;
     }
 
     default:

--- a/src/lib/utils/traceUtils.ts
+++ b/src/lib/utils/traceUtils.ts
@@ -62,6 +62,7 @@ export function summariseEntry(entry: EntryWithLabels): string {
       if (!label) return 'Felt';
       const parentName = label.parentName;
       const stateName = shouldShowAreaPrefix(parentName) ? `${parentName}: ${label.name}` : label.name;
+      if (numericValue === 0) return `Felt ${stateName} (absent)`;
       return numericValue != null ? `Felt ${stateName} (${numericValue}/5)` : `Felt ${stateName}`;
     }
 

--- a/src/lib/utils/traceUtils.ts
+++ b/src/lib/utils/traceUtils.ts
@@ -63,7 +63,7 @@ export function summariseEntry(entry: EntryWithLabels): string {
       const parentName = label.parentName;
       const stateName = shouldShowAreaPrefix(parentName) ? `${parentName}: ${label.name}` : label.name;
       if (numericValue === 0) return `Felt ${stateName} (absent)`;
-      return numericValue !== null && numericValue !== 0
+      return numericValue !== null
         ? `Felt ${stateName} (${numericValue}/5)`
         : `Felt ${stateName}`;
     }


### PR DESCRIPTION
## Summary

- Extends the Physical severity scale from 1–5 to 0–5, where 0 means the tracked symptom is absent today
- Adds a dedicated "0" button to SeverityRow so users can explicitly log zero-severity check-ins — filling in the missing data points that make over-time charts meaningful
- Extracts `formatChipLabel` into a shared utility and renders "(absent)" for severity-0 chips in Trace so logged absences are readable in history

Closes #140
Contributes to #111

## What to review

- `SeverityRow` — layout with the added 0 button; make sure it doesn't read as an error/empty state
- `formatChipLabel` utility — extracted from existing inline logic; verify all callers still behave correctly
- Trace chip rendering for severity 0 — the "(absent)" label is the only place this semantic is surfaced to the user

## Testing

- Updated unit tests for `formatChipLabel` covering severity 0
- Manual: select a Physical label, tap 0 in severity row, save; confirm chip shows "(absent)" in Trace

## Checklist
- [x] Acceptance criteria met
- [x] Flow tests (Maestro) added or updated for any user-facing behavior
- [ ] Migration test written if schema changed
- [x] CI passing
- [x] docs/changelog.md updated
- [x] No judgmental language in UI strings
- [x] No network calls or off-device data transmission introduced