### PR TITLE
Settings — Routines management section

### DIFF
--- a/app/(tabs)/__tests__/settings.test.tsx
+++ b/app/(tabs)/__tests__/settings.test.tsx
@@ -172,18 +172,20 @@ describe('SettingsScreen — Routines section', () => {
     expect(mockPush).toHaveBeenCalledWith('/routine/create');
   });
 
-  it('hides + Add Routine when active routines exist', async () => {
+  it('keeps + Add Routine visible alongside active routines', async () => {
+    // Settings is the canonical create-anytime surface, so + Add Routine is
+    // always available — not gated on the empty state.
     mockGetRoutines.mockResolvedValue([ACTIVE_ROUTINE]);
-    const { queryByTestId, getByTestId } = render(<SettingsScreen />);
+    const { getByTestId } = render(<SettingsScreen />);
     await waitFor(() => getByTestId(`settings-routine-row-${ACTIVE_ROUTINE.id}`));
-    expect(queryByTestId('settings-routines-add-row')).toBeNull();
+    expect(getByTestId('settings-routines-add-row')).toBeTruthy();
   });
 
-  it('hides + Add Routine when only archived routines exist', async () => {
+  it('keeps + Add Routine visible alongside archived routines', async () => {
     mockGetRoutines.mockResolvedValue([ARCHIVED_ROUTINE]);
-    const { queryByTestId, getByTestId } = render(<SettingsScreen />);
+    const { getByTestId } = render(<SettingsScreen />);
     await waitFor(() => getByTestId(`settings-routine-archived-row-${ARCHIVED_ROUTINE.id}`));
-    expect(queryByTestId('settings-routines-add-row')).toBeNull();
+    expect(getByTestId('settings-routines-add-row')).toBeTruthy();
   });
 
   it('shows active routine rows with a gear icon', async () => {
@@ -228,9 +230,9 @@ describe('SettingsScreen — Routines section', () => {
     });
   });
 
-  it('does not show + Add Routine after optimistically unarchiving the only routine', async () => {
-    // The hook does not refetch, so the unarchived routine still counts as an
-    // existing routine — + Add Routine must stay hidden (allRoutines.length > 0).
+  it('keeps + Add Routine visible after optimistically unarchiving the only routine', async () => {
+    // + Add Routine is always present, so it stays visible through the
+    // optimistic unarchive (the archived row disappears, the add row does not).
     mockGetRoutines.mockResolvedValue([ARCHIVED_ROUTINE]);
     const { getByTestId, queryByTestId } = render(<SettingsScreen />);
     await waitFor(() => getByTestId(`settings-routine-unarchive-${ARCHIVED_ROUTINE.id}`));
@@ -242,7 +244,7 @@ describe('SettingsScreen — Routines section', () => {
     await waitFor(() => {
       expect(queryByTestId(`settings-routine-archived-row-${ARCHIVED_ROUTINE.id}`)).toBeNull();
     });
-    expect(queryByTestId('settings-routines-add-row')).toBeNull();
+    expect(getByTestId('settings-routines-add-row')).toBeTruthy();
   });
 
   it('shows the archived row again when setRoutineArchived throws', async () => {

--- a/app/(tabs)/__tests__/settings.test.tsx
+++ b/app/(tabs)/__tests__/settings.test.tsx
@@ -15,9 +15,13 @@ jest.mock('@/lib/db/database', () => ({
 
 const mockSetFocusArchived = jest.fn();
 const mockGetFocuses = jest.fn();
+const mockSetRoutineArchived = jest.fn();
+const mockGetRoutines = jest.fn();
 jest.mock('@/lib/db/queries', () => ({
   getFocuses: (...args: unknown[]) => mockGetFocuses(...args),
   setFocusArchived: (...args: unknown[]) => mockSetFocusArchived(...args),
+  getRoutines: (...args: unknown[]) => mockGetRoutines(...args),
+  setRoutineArchived: (...args: unknown[]) => mockSetRoutineArchived(...args),
 }));
 
 // ─── fixtures ─────────────────────────────────────────────────────────────────
@@ -25,12 +29,24 @@ jest.mock('@/lib/db/queries', () => ({
 const ACTIVE_FOCUS = { id: 1, name: 'Energy', description: null, archived: false, sortOrder: 0, createdAt: '' };
 const ARCHIVED_FOCUS = { id: 2, name: 'Old Focus', description: null, archived: true, sortOrder: 1, createdAt: '' };
 
+const ACTIVE_ROUTINE = {
+  id: 10, name: 'Morning Reset', associatedFocusId: null,
+  frequencyNote: null, sortOrder: 0, archived: false,
+  createdAt: '', updatedAt: '', timeBlocks: [],
+};
+const ARCHIVED_ROUTINE = {
+  id: 11, name: 'Old Routine', associatedFocusId: null,
+  frequencyNote: null, sortOrder: 1, archived: true,
+  createdAt: '', updatedAt: '', timeBlocks: [],
+};
+
 // eslint-disable-next-line import/first
 import SettingsScreen from '../settings';
 
 describe('SettingsScreen — visual hierarchy', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockGetRoutines.mockResolvedValue([]);
   });
 
   it('shows a section divider between Privacy and Focus (always rendered)', async () => {
@@ -54,6 +70,7 @@ describe('SettingsScreen — Focus section', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockSetFocusArchived.mockResolvedValue(undefined);
+    mockGetRoutines.mockResolvedValue([]);
   });
 
   it('hides Focus section when there are no focuses', async () => {
@@ -118,6 +135,136 @@ describe('SettingsScreen — Focus section', () => {
 
     await waitFor(() => {
       expect(getByTestId(`settings-focus-archived-row-${ARCHIVED_FOCUS.id}`)).toBeTruthy();
+    });
+  });
+});
+
+describe('SettingsScreen — Routines section', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSetRoutineArchived.mockResolvedValue(undefined);
+    mockGetFocuses.mockResolvedValue([]);
+  });
+
+  it('shows the Routines section heading even with no routines', async () => {
+    mockGetRoutines.mockResolvedValue([]);
+    const { queryByText } = render(<SettingsScreen />);
+    await waitFor(() => {
+      expect(queryByText('Routines')).not.toBeNull();
+    });
+  });
+
+  it('shows + Add Routine when no routines exist', async () => {
+    mockGetRoutines.mockResolvedValue([]);
+    const { getByTestId } = render(<SettingsScreen />);
+    await waitFor(() => {
+      expect(getByTestId('settings-routines-add-row')).toBeTruthy();
+      expect(getByTestId('settings-routines-add-button')).toBeTruthy();
+    });
+  });
+
+  it('tapping + Add Routine navigates to /routine/create', async () => {
+    mockGetRoutines.mockResolvedValue([]);
+    const { getByTestId } = render(<SettingsScreen />);
+    await waitFor(() => getByTestId('settings-routines-add-button'));
+
+    fireEvent.press(getByTestId('settings-routines-add-button'));
+    expect(mockPush).toHaveBeenCalledWith('/routine/create');
+  });
+
+  it('hides + Add Routine when active routines exist', async () => {
+    mockGetRoutines.mockResolvedValue([ACTIVE_ROUTINE]);
+    const { queryByTestId, getByTestId } = render(<SettingsScreen />);
+    await waitFor(() => getByTestId(`settings-routine-row-${ACTIVE_ROUTINE.id}`));
+    expect(queryByTestId('settings-routines-add-row')).toBeNull();
+  });
+
+  it('hides + Add Routine when only archived routines exist', async () => {
+    mockGetRoutines.mockResolvedValue([ARCHIVED_ROUTINE]);
+    const { queryByTestId, getByTestId } = render(<SettingsScreen />);
+    await waitFor(() => getByTestId(`settings-routine-archived-row-${ARCHIVED_ROUTINE.id}`));
+    expect(queryByTestId('settings-routines-add-row')).toBeNull();
+  });
+
+  it('shows active routine rows with a gear icon', async () => {
+    mockGetRoutines.mockResolvedValue([ACTIVE_ROUTINE]);
+    const { getByTestId } = render(<SettingsScreen />);
+    await waitFor(() => {
+      expect(getByTestId(`settings-routine-row-${ACTIVE_ROUTINE.id}`)).toBeTruthy();
+      expect(getByTestId(`settings-routine-edit-${ACTIVE_ROUTINE.id}`)).toBeTruthy();
+    });
+  });
+
+  it('tapping gear icon navigates to the edit screen', async () => {
+    mockGetRoutines.mockResolvedValue([ACTIVE_ROUTINE]);
+    const { getByTestId } = render(<SettingsScreen />);
+    await waitFor(() => getByTestId(`settings-routine-edit-${ACTIVE_ROUTINE.id}`));
+
+    fireEvent.press(getByTestId(`settings-routine-edit-${ACTIVE_ROUTINE.id}`));
+    expect(mockPush).toHaveBeenCalledWith(`/routine/${ACTIVE_ROUTINE.id}/edit`);
+  });
+
+  it('shows archived routine with an Unarchive button', async () => {
+    mockGetRoutines.mockResolvedValue([ARCHIVED_ROUTINE]);
+    const { getByTestId } = render(<SettingsScreen />);
+    await waitFor(() => {
+      expect(getByTestId(`settings-routine-archived-row-${ARCHIVED_ROUTINE.id}`)).toBeTruthy();
+      expect(getByTestId(`settings-routine-unarchive-${ARCHIVED_ROUTINE.id}`)).toBeTruthy();
+    });
+  });
+
+  it('tapping Unarchive calls setRoutineArchived(false) and hides the row optimistically', async () => {
+    mockGetRoutines.mockResolvedValue([ARCHIVED_ROUTINE]);
+    const { getByTestId, queryByTestId } = render(<SettingsScreen />);
+    await waitFor(() => getByTestId(`settings-routine-unarchive-${ARCHIVED_ROUTINE.id}`));
+
+    await act(async () => {
+      fireEvent.press(getByTestId(`settings-routine-unarchive-${ARCHIVED_ROUTINE.id}`));
+    });
+
+    await waitFor(() => {
+      expect(mockSetRoutineArchived).toHaveBeenCalledWith(expect.anything(), ARCHIVED_ROUTINE.id, false);
+      expect(queryByTestId(`settings-routine-archived-row-${ARCHIVED_ROUTINE.id}`)).toBeNull();
+    });
+  });
+
+  it('does not show + Add Routine after optimistically unarchiving the only routine', async () => {
+    // The hook does not refetch, so the unarchived routine still counts as an
+    // existing routine — + Add Routine must stay hidden (allRoutines.length > 0).
+    mockGetRoutines.mockResolvedValue([ARCHIVED_ROUTINE]);
+    const { getByTestId, queryByTestId } = render(<SettingsScreen />);
+    await waitFor(() => getByTestId(`settings-routine-unarchive-${ARCHIVED_ROUTINE.id}`));
+
+    await act(async () => {
+      fireEvent.press(getByTestId(`settings-routine-unarchive-${ARCHIVED_ROUTINE.id}`));
+    });
+
+    await waitFor(() => {
+      expect(queryByTestId(`settings-routine-archived-row-${ARCHIVED_ROUTINE.id}`)).toBeNull();
+    });
+    expect(queryByTestId('settings-routines-add-row')).toBeNull();
+  });
+
+  it('shows the archived row again when setRoutineArchived throws', async () => {
+    mockGetRoutines.mockResolvedValue([ARCHIVED_ROUTINE]);
+    mockSetRoutineArchived.mockRejectedValue(new Error('DB error'));
+    const { getByTestId } = render(<SettingsScreen />);
+    await waitFor(() => getByTestId(`settings-routine-unarchive-${ARCHIVED_ROUTINE.id}`));
+
+    await act(async () => {
+      fireEvent.press(getByTestId(`settings-routine-unarchive-${ARCHIVED_ROUTINE.id}`));
+    });
+
+    await waitFor(() => {
+      expect(getByTestId(`settings-routine-archived-row-${ARCHIVED_ROUTINE.id}`)).toBeTruthy();
+    });
+  });
+
+  it('always renders the second section divider, even with no routines', async () => {
+    mockGetRoutines.mockResolvedValue([]);
+    const { getByTestId } = render(<SettingsScreen />);
+    await waitFor(() => {
+      expect(getByTestId('settings-routines-divider')).toBeTruthy();
     });
   });
 });

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -97,7 +97,7 @@ function SettingsFocusSection() {
                 testID={`settings-focus-unarchive-${focus.id}`}
                 hitSlop={8}
               >
-                <Text style={styles.unarchiveText}>Unarchive</Text>
+                <Text style={styles.interactiveLabel}>Unarchive</Text>
               </Pressable>
             </Surface>
           ))}
@@ -145,7 +145,7 @@ function SettingsRoutinesSection() {
             accessibilityLabel="Add Routine"
             testID="settings-routines-add-button"
           >
-            <Text style={styles.addRoutineText}>+ Add Routine</Text>
+            <Text style={styles.interactiveLabel}>+ Add Routine</Text>
           </Pressable>
         </Surface>
       )}
@@ -187,7 +187,7 @@ function SettingsRoutinesSection() {
                 testID={`settings-routine-unarchive-${routine.id}`}
                 hitSlop={8}
               >
-                <Text style={styles.unarchiveText}>Unarchive</Text>
+                <Text style={styles.interactiveLabel}>Unarchive</Text>
               </Pressable>
             </Surface>
           ))}
@@ -255,13 +255,7 @@ const styles = StyleSheet.create({
   archivedHeading: {
     marginTop: spacing.elementGap,
   },
-  unarchiveText: {
-    fontFamily: typeScale.labelMedium.family,
-    fontSize: typeScale.labelMedium.size,
-    lineHeight: lineHeight(typeScale.labelMedium),
-    color: colors.interactive,
-  },
-  addRoutineText: {
+  interactiveLabel: {
     fontFamily: typeScale.labelMedium.family,
     fontSize: typeScale.labelMedium.size,
     lineHeight: lineHeight(typeScale.labelMedium),

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -137,19 +137,6 @@ function SettingsRoutinesSection() {
     <View style={styles.section}>
       <Text style={sectionLabelStyle}>Routines</Text>
 
-      {allRoutines.length === 0 && (
-        <Surface style={styles.focusRow} testID="settings-routines-add-row">
-          <Pressable
-            onPress={() => router.push('/routine/create')}
-            accessibilityRole="button"
-            accessibilityLabel="Add Routine"
-            testID="settings-routines-add-button"
-          >
-            <Text style={styles.interactiveLabel}>+ Add Routine</Text>
-          </Pressable>
-        </Surface>
-      )}
-
       {activeRoutines.map((routine) => (
         <Surface
           key={routine.id}
@@ -193,6 +180,19 @@ function SettingsRoutinesSection() {
           ))}
         </View>
       )}
+
+      {/* + Add Routine is always available — Settings is the canonical
+          create-anytime surface for Routine management. */}
+      <Surface style={styles.focusRow} testID="settings-routines-add-row">
+        <Pressable
+          onPress={() => router.push('/routine/create')}
+          accessibilityRole="button"
+          accessibilityLabel="Add Routine"
+          testID="settings-routines-add-button"
+        >
+          <Text style={styles.interactiveLabel}>+ Add Routine</Text>
+        </Pressable>
+      </Surface>
     </View>
   );
 }

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -3,11 +3,12 @@ import { Pressable, StyleSheet, Text, View } from 'react-native';
 import { useRouter } from 'expo-router';
 import { Screen, Surface } from '@/components';
 import { useFocuses } from '@/hooks/useFocuses';
-import { setFocusArchived } from '@/lib/db/queries';
+import { useRoutines } from '@/hooks/useRoutines';
+import { setFocusArchived, setRoutineArchived } from '@/lib/db/queries';
 import { getDb } from '@/lib/db/database';
 import { colors, lineHeight, spacing, typeScale } from '@/constants/theme';
 import type { Db } from '@/lib/db/queries';
-import type { Focus } from '@/lib/db/query-types';
+import type { Focus, Routine } from '@/lib/db/query-types';
 
 const sectionLabelStyle = {
   fontFamily: typeScale.titleMedium.family,
@@ -106,6 +107,96 @@ function SettingsFocusSection() {
   );
 }
 
+function SettingsRoutinesSection() {
+  const router = useRouter();
+  const { routines: allRoutines } = useRoutines({ includeArchived: true });
+
+  const [unarchiving, setUnarchiving] = useState<number | null>(null);
+  // Local optimistic state: track IDs that have been unarchived in this session
+  const [locallyUnarchived, setLocallyUnarchived] = useState<Set<number>>(new Set());
+
+  const activeRoutines = allRoutines.filter((r) => !r.archived);
+  const archivedRoutines = allRoutines.filter(
+    (r) => r.archived && !locallyUnarchived.has(r.id)
+  );
+
+  async function handleUnarchive(routine: Routine) {
+    setUnarchiving(routine.id);
+    try {
+      const db = (await getDb()) as unknown as Db;
+      await setRoutineArchived(db, routine.id, false);
+      setLocallyUnarchived((prev) => new Set([...prev, routine.id]));
+    } catch {
+      // unarchive failed — row remains visible; user can retry
+    } finally {
+      setUnarchiving(null);
+    }
+  }
+
+  return (
+    <View style={styles.section}>
+      <Text style={sectionLabelStyle}>Routines</Text>
+
+      {allRoutines.length === 0 && (
+        <Surface style={styles.focusRow} testID="settings-routines-add-row">
+          <Pressable
+            onPress={() => router.push('/routine/create')}
+            accessibilityRole="button"
+            accessibilityLabel="Add Routine"
+            testID="settings-routines-add-button"
+          >
+            <Text style={styles.addRoutineText}>+ Add Routine</Text>
+          </Pressable>
+        </Surface>
+      )}
+
+      {activeRoutines.map((routine) => (
+        <Surface
+          key={routine.id}
+          style={styles.focusRow}
+          testID={`settings-routine-row-${routine.id}`}
+        >
+          <Text style={focusNameStyle}>{routine.name}</Text>
+          <Pressable
+            onPress={() => router.push(`/routine/${routine.id}/edit`)}
+            accessibilityRole="button"
+            accessibilityLabel={`Edit ${routine.name}`}
+            testID={`settings-routine-edit-${routine.id}`}
+            hitSlop={8}
+          >
+            <Text style={styles.settingsIcon}>⚙</Text>
+          </Pressable>
+        </Surface>
+      ))}
+
+      {archivedRoutines.length > 0 && (
+        <View style={styles.archivedGroup}>
+          <Text style={[sectionLabelStyle, styles.archivedHeading]}>Archived</Text>
+          {archivedRoutines.map((routine) => (
+            <Surface
+              key={routine.id}
+              style={styles.focusRow}
+              testID={`settings-routine-archived-row-${routine.id}`}
+            >
+              <Text style={focusNameStyle}>{routine.name}</Text>
+              <Pressable
+                onPress={() => { void handleUnarchive(routine); }}
+                disabled={unarchiving === routine.id}
+                accessibilityRole="button"
+                accessibilityLabel={`Unarchive ${routine.name}`}
+                testID={`settings-routine-unarchive-${routine.id}`}
+                hitSlop={8}
+              >
+                <Text style={styles.unarchiveText}>Unarchive</Text>
+              </Pressable>
+            </Surface>
+          ))}
+        </View>
+      )}
+    </View>
+  );
+}
+
 export default function SettingsScreen() {
   return (
     <Screen>
@@ -129,6 +220,10 @@ export default function SettingsScreen() {
       <View style={styles.sectionDivider} testID="settings-section-divider" />
 
       <SettingsFocusSection />
+
+      <View style={styles.sectionDivider} testID="settings-routines-divider" />
+
+      <SettingsRoutinesSection />
     </Screen>
   );
 }
@@ -161,6 +256,12 @@ const styles = StyleSheet.create({
     marginTop: spacing.elementGap,
   },
   unarchiveText: {
+    fontFamily: typeScale.labelMedium.family,
+    fontSize: typeScale.labelMedium.size,
+    lineHeight: lineHeight(typeScale.labelMedium),
+    color: colors.interactive,
+  },
+  addRoutineText: {
     fontFamily: typeScale.labelMedium.family,
     fontSize: typeScale.labelMedium.size,
     lineHeight: lineHeight(typeScale.labelMedium),

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,7 @@ One row per PR. Most recent at the top.
 
 | PR | Description | Date |
 |----|-------------|------|
+| [#174](https://github.com/sfrankle/haven-app/pull/174) | Settings gains a Routines section: edit active Routines, restore archived ones, and add a new Routine when none exist | 2026-06-05 |
 | [#171](https://github.com/sfrankle/haven-app/pull/171) | Complete a Routine screen: checklist with static prescribed detail, batch entry creation on submit, unchecked items skipped, Focus auto-association, and 29 unit tests | 2026-05-24 |
 | [#168](https://github.com/sfrankle/haven-app/pull/168) | Create and edit Routine screens: shared form, reorderable items (name, entry type, labels, prescribed detail), time-block multi-select, and archive option | 2026-05-23 |
 | [#167](https://github.com/sfrankle/haven-app/pull/167) | Routine data layer: `ScheduleableBlock` type, six query functions, `useRoutines` and `useRoutineCompletionStates` hooks, and 37 unit tests covering all completion state logic | 2026-05-22 |

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,7 +4,7 @@ One row per PR. Most recent at the top.
 
 | PR | Description | Date |
 |----|-------------|------|
-| [#174](https://github.com/sfrankle/haven-app/pull/174) | Settings gains a Routines section: edit active Routines, restore archived ones, and add a new Routine when none exist | 2026-06-05 |
+| [#174](https://github.com/sfrankle/haven-app/pull/174) | Settings gains a Routines section: edit active Routines, restore archived ones, and add a new Routine anytime | 2026-06-05 |
 | [#171](https://github.com/sfrankle/haven-app/pull/171) | Complete a Routine screen: checklist with static prescribed detail, batch entry creation on submit, unchecked items skipped, Focus auto-association, and 29 unit tests | 2026-05-24 |
 | [#168](https://github.com/sfrankle/haven-app/pull/168) | Create and edit Routine screens: shared form, reorderable items (name, entry type, labels, prescribed detail), time-block multi-select, and archive option | 2026-05-23 |
 | [#167](https://github.com/sfrankle/haven-app/pull/167) | Routine data layer: `ScheduleableBlock` type, six query functions, `useRoutines` and `useRoutineCompletionStates` hooks, and 37 unit tests covering all completion state logic | 2026-05-22 |

--- a/maestro/flows/settings/settings-routines.yaml
+++ b/maestro/flows/settings/settings-routines.yaml
@@ -1,0 +1,10 @@
+appId: com.haven.app
+---
+# Verify the Routines section appears in Settings.
+# This flow relies on the app having no existing routines (fresh install /
+# cleared state), so the + Add Routine entry is visible.
+
+- launchApp
+- tapOn: "Settings"
+- assertVisible: "Routines"
+- assertVisible: "+ Add Routine"

--- a/maestro/flows/tend/routine-create-edit.yaml
+++ b/maestro/flows/tend/routine-create-edit.yaml
@@ -1,10 +1,11 @@
 # Routine create/edit E2E flow
 #
-# TODO: The navigation entry points for the Routine create and edit screens
-# ("+Add Routine" button on the Tend tab and "Routines" in Settings) are wired
-# in a separate issue. Until that work lands, this flow cannot be launched from
-# a natural in-app tap. The assertions below describe the intended behavior and
-# will be activated once the calling screens exist.
+# NOTE: Settings now has a live "Routines" section with a "+ Add Routine"
+# entry (see maestro/flows/settings/settings-routines.yaml) — this flow can be
+# updated to navigate via Settings → Routines → + Add Routine. The Tend tab
+# "+ Add Routine" entry point is still wired in a separate issue. Until that
+# Tend work lands, the assertions below describe the intended Tend behavior and
+# will be activated once the Tend calling screen exists.
 #
 # To validate in the meantime you can deep-link directly to the create screen:
 #   appId: com.haven.app


### PR DESCRIPTION
## Summary
- Adds a Routines management section to the Settings screen, directly below the Focus section.
- Mirrors the existing `SettingsFocusSection` pattern: active Routines list with an edit affordance, an Archived group with optimistic unarchive, and a persistent `+ Add Routine` entry.
- Lets users edit a Routine from Settings and restore an archived one without leaving the screen.

Closes #162
Contributes to #123

## What to review
- `app/(tabs)/settings.tsx` — the new `SettingsRoutinesSection` component. Worth a look: the optimistic unarchive uses a local `locallyUnarchived` Set (same approach as the archived Focus unarchive) so the row disappears immediately while the write is in flight, and a failed write leaves the row visible for retry.
- `+ Add Routine` renders persistently at the bottom of the section (not gated on the empty state) so users with existing Routines can always create another — Settings is the canonical create-anytime surface while the Tend entry point is deferred to #163.
- Section ordering and divider placement in `SettingsScreen`.

## Testing
- Added unit tests in `app/(tabs)/__tests__/settings.test.tsx` covering active and archived Routine rendering, the persistent `+ Add Routine` entry, edit navigation, and the unarchive interaction.
- Added a Maestro flow `maestro/flows/settings/settings-routines.yaml` asserting the Routines section and `+ Add Routine` entry are visible on a fresh install.
- Updated `maestro/flows/tend/routine-create-edit.yaml` notes now that a live Settings entry point exists.
- `npx tsc --noEmit`, `npx eslint`, and `npm test` run locally.

## Checklist
- [x] Acceptance criteria met
- [x] Flow tests (Maestro) added or updated for any user-facing behavior
- [ ] Migration test written if schema changed
- [x] CI passing
- [x] \`docs/changelog.md\` updated
- [x] No judgmental language in UI strings
- [x] No network calls or off-device data transmission introduced